### PR TITLE
bugfix quick view

### DIFF
--- a/src/c/swiss_german.c
+++ b/src/c/swiss_german.c
@@ -60,7 +60,7 @@ static void prv_unobstructed_change(AnimationProgress progress, void *context) {
 
 static void window_load(Window *window) {
   Layer *window_layer = window_get_root_layer(window);
-  GRect bounds = layer_get_bounds(window_layer);
+  GRect bounds = layer_get_unobstructed_bounds(window_layer);
   init_text_layers(bounds);
   layer_add_child(window_layer, text_layer_get_layer(minuteLayer));
   text_layer_enable_screen_text_flow_and_paging(minuteLayer, 0);


### PR DESCRIPTION
fixed small bug with the quick view (aka timeline peek) where it wouldn't adapt to the limited space when your coming back from the menu. Now using unobstructed bounds everywhere.
